### PR TITLE
added option to reset streaming connection in sampler

### DIFF
--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerGui.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerGui.java
@@ -59,6 +59,7 @@ public class WebSocketSamplerGui extends AbstractSamplerGui {
             webSocketSamplerPanel.setConnectionTimeout(webSocketSamplerTestElement.getConnectionTimeout());
             webSocketSamplerPanel.setIgnoreSslErrors(webSocketSamplerTestElement.isIgnoreSslErrors());
             webSocketSamplerPanel.setStreamingConnection(webSocketSamplerTestElement.isStreamingConnection());
+            webSocketSamplerPanel.setResetStreamingConnection(webSocketSamplerTestElement.isResetStreamingConnection());
             webSocketSamplerPanel.setConnectionId(webSocketSamplerTestElement.getConnectionId());
             webSocketSamplerPanel.setResponsePattern(webSocketSamplerTestElement.getResponsePattern());
             webSocketSamplerPanel.setCloseConncectionPattern(webSocketSamplerTestElement.getCloseConncectionPattern());
@@ -98,6 +99,7 @@ public class WebSocketSamplerGui extends AbstractSamplerGui {
             webSocketSamplerTestElement.setResponseTimeout(webSocketSamplerPanel.getResponseTimeout());
             webSocketSamplerTestElement.setIgnoreSslErrors(webSocketSamplerPanel.isIgnoreSslErrors());
             webSocketSamplerTestElement.setStreamingConnection(webSocketSamplerPanel.isStreamingConnection());
+            webSocketSamplerTestElement.setResetStreamingConnection(webSocketSamplerPanel.isResetStreamingConnection());
             webSocketSamplerTestElement.setConnectionId(webSocketSamplerPanel.getConnectionId());
             webSocketSamplerTestElement.setResponsePattern(webSocketSamplerPanel.getResponsePattern());
             webSocketSamplerTestElement.setCloseConncectionPattern(webSocketSamplerPanel.getCloseConncectionPattern());

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.form
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.form
@@ -207,6 +207,8 @@
                                   <Component id="ignoreSslErrorsCheckBox" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                                   <Component id="streamingConnectionCheckBox" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <Component id="resetStreamingConnectionCheckBox" min="-2" max="-2" attributes="0"/>
                               </Group>
                           </Group>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
@@ -244,6 +246,7 @@
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="ignoreSslErrorsCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="streamingConnectionCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="resetStreamingConnectionCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace min="-2" max="-2" attributes="0"/>
                   <Component id="querystringAttributesPanel" pref="102" max="32767" attributes="0"/>
@@ -330,6 +333,11 @@
         <Component class="javax.swing.JCheckBox" name="streamingConnectionCheckBox">
           <Properties>
             <Property name="text" type="java.lang.String" value="Streaming connection"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="resetStreamingConnectionCheckBox">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Reset streaming connection"/>
           </Properties>
         </Component>
       </SubComponents>

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.java
@@ -64,6 +64,7 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
         jLabel15 = new javax.swing.JLabel();
         implementationComboBox = new javax.swing.JComboBox();
         streamingConnectionCheckBox = new javax.swing.JCheckBox();
+        resetStreamingConnectionCheckBox = new javax.swing.JCheckBox();
         jPanel5 = new javax.swing.JPanel();
         jLabel7 = new javax.swing.JLabel();
         responsePatternTextField = new javax.swing.JTextField();
@@ -172,6 +173,8 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
         implementationComboBox.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "RFC6455 (v13)" }));
 
         streamingConnectionCheckBox.setText("Streaming connection");
+        
+        resetStreamingConnectionCheckBox.setText("Reset streaming connection");
 
         javax.swing.GroupLayout jPanel3Layout = new javax.swing.GroupLayout(jPanel3);
         jPanel3.setLayout(jPanel3Layout);
@@ -204,7 +207,9 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
                             .addGroup(jPanel3Layout.createSequentialGroup()
                                 .addComponent(ignoreSslErrorsCheckBox)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                .addComponent(streamingConnectionCheckBox)))
+                                .addComponent(streamingConnectionCheckBox)
+                                .addComponent(resetStreamingConnectionCheckBox)
+                                ))
                         .addGap(0, 0, Short.MAX_VALUE))
                     .addGroup(jPanel3Layout.createSequentialGroup()
                         .addComponent(jLabel5)
@@ -232,7 +237,8 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(ignoreSslErrorsCheckBox)
-                    .addComponent(streamingConnectionCheckBox))
+                    .addComponent(streamingConnectionCheckBox)
+                    .addComponent(resetStreamingConnectionCheckBox))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(querystringAttributesPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 102, Short.MAX_VALUE)
                 .addGap(8, 8, 8)
@@ -425,6 +431,7 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
     private javax.swing.JTextField serverAddressTextField;
     private javax.swing.JTextField serverPortTextField;
     private javax.swing.JCheckBox streamingConnectionCheckBox;
+    private javax.swing.JCheckBox resetStreamingConnectionCheckBox;
     // End of variables declaration//GEN-END:variables
 
     public void initFields() {
@@ -549,13 +556,21 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
     public String getRequestPayload() {
         return requestPayloadEditorPane.getText();
     }
-
+    
     public void setStreamingConnection(Boolean streamingConnection) {
         streamingConnectionCheckBox.setSelected(streamingConnection);
     }
-
+    
     public Boolean isStreamingConnection() {
         return streamingConnectionCheckBox.isSelected();
+    }
+
+    public void setResetStreamingConnection(Boolean resetStreamingConnection) {
+        resetStreamingConnectionCheckBox.setSelected(resetStreamingConnection);
+    }
+
+    public Boolean isResetStreamingConnection() {
+        return resetStreamingConnectionCheckBox.isSelected();
     }
 
     public void setIgnoreSslErrors(Boolean ignoreSslErrors) {


### PR DESCRIPTION
In our test case, we create a new streaming connection for every thread loop, which is used only in that exact loop. In long running tests we want to prevent unused streaming connections from filling up the memory, so we need to make sure the connections get closed after every loop (the response pattern unfortunately is too unreliable here). As a solution, we added the option "Reset streaming connection" to the sampler to close any existing streaming connection under the given name and create a new one.

Additionally, we moved initialization and shutdown of the ExecutorService to the testStarted/testEnded methods, as not shutting down the ExecutorService properly resulted in the JVM not exiting after the test had finished.