### PR TITLE
Override previous patterns on new sampler

### DIFF
--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/ServiceSocket.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/ServiceSocket.java
@@ -53,13 +53,11 @@ public class ServiceSocket {
     public ServiceSocket(WebSocketSampler parent, WebSocketClient client) {
         this.parent = parent;
         this.client = client;
-        
-        //Evaluate response matching patterns in case thay contain JMeter variables (i.e. ${var})
-        responsePattern = new CompoundVariable(parent.getResponsePattern()).execute();
-        disconnectPattern = new CompoundVariable(parent.getCloseConncectionPattern()).execute();
+
+        setResponsePattern(parent.getResponsePattern());
+        setDisconnectPattern(parent.getCloseConncectionPattern());        
         logMessage.append("\n\n[Execution Flow]\n");
         logMessage.append(" - Opening new connection\n");
-        initializePatterns();
     }
 
     @OnWebSocketMessage
@@ -233,7 +231,17 @@ public class ServiceSocket {
         logMessage.append(message);
     }
 
-    protected void initializePatterns() {
+    /**
+     * Resets the patterns used to end a sample
+     * @param newResponsePattern    the new response pattern to use
+     */
+    protected void setResponsePattern(String newResponsePattern) {
+        // Evaluate response matching patterns in case thay contain JMeter variables (i.e. ${var})
+        responsePattern = new CompoundVariable(newResponsePattern).execute();
+        initializeResponsePattern();
+    }
+
+    private void initializeResponsePattern() {
         try {
             logMessage.append(" - Using response message pattern \"").append(responsePattern).append("\"\n");
             responseExpression = (responsePattern != null || !responsePattern.isEmpty()) ? Pattern.compile(responsePattern) : null;
@@ -242,7 +250,19 @@ public class ServiceSocket {
             log.error("Invalid response message regular expression pattern: " + ex.getLocalizedMessage());
             responseExpression = null;
         }
+    }
 
+    /**
+     * Resets the patterns used to close the connection
+     * @param newDisconnectPattern  the new disconnect pattern to use
+     */
+    protected void setDisconnectPattern(String newDisconnectPattern) {
+        // Evaluate response matching patterns in case thay contain JMeter variables (i.e. ${var})
+        disconnectPattern = new CompoundVariable(newDisconnectPattern).execute();
+        initializeDisconnectPattern();
+    }
+
+    private void initializeDisconnectPattern() {
         try {
             logMessage.append(" - Using disconnect pattern \"").append(disconnectPattern).append("\"\n");
             disconnectExpression = (disconnectPattern != null || !disconnectPattern.isEmpty()) ? Pattern.compile(disconnectPattern) : null;
@@ -251,7 +271,6 @@ public class ServiceSocket {
             log.error("Invalid disconnect regular regular expression pattern: " + ex.getLocalizedMessage());
             disconnectExpression = null;
         }
-
     }
 
     /**

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSampler.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSampler.java
@@ -74,9 +74,14 @@ public class WebSocketSampler extends AbstractSampler implements TestStateListen
         	ServiceSocket socket = connectionList.get(connectionId);
             socket.initialize();
 
-            // use new response and disconnect patterns
-            socket.setResponsePattern(this.getResponsePattern());
-            socket.setDisconnectPattern(this.getCloseConncectionPattern());
+            // use new response and disconnect patterns if overriden
+            if (this.isOverrideResponsePattern()) {
+                socket.setResponsePattern(this.getResponsePattern());
+            }
+            
+            if (this.isOverrideDisconnectPattern()) {
+                socket.setDisconnectPattern(this.getCloseConncectionPattern());
+            }
             
             return socket;
         }
@@ -389,6 +394,22 @@ public class WebSocketSampler extends AbstractSampler implements TestStateListen
             return getPropertyAsString("closeConncectionPattern");
     }
 
+    void setOverrideResponsePattern(Boolean overrideResponsePattern) {
+        setProperty("isOverrideResponsePattern", overrideResponsePattern);
+    }
+    
+    Boolean isOverrideResponsePattern() {
+        return getPropertyAsBoolean("isOverrideResponsePattern", false);
+    }
+
+    void setOverrideDisconnectPattern(Boolean overrideDisconnectPattern) {
+        setProperty("isOverrideDisconnectPattern", overrideDisconnectPattern);
+    }
+
+    Boolean isOverrideDisconnectPattern() {
+        return getPropertyAsBoolean("isOverrideDisconnectPattern", false);
+    }
+    
     public void setProxyAddress(String proxyAddress) {
             setProperty("proxyAddress", proxyAddress);
     }
@@ -505,7 +526,5 @@ public class WebSocketSampler extends AbstractSampler implements TestStateListen
             socket.close();
         }
     }
-
-
 
 }

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSampler.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSampler.java
@@ -69,9 +69,15 @@ public class WebSocketSampler extends AbstractSampler implements TestStateListen
 
         String connectionId = getThreadName() + getConnectionId();
         
+        // Get the existing socket for this client
         if (isStreamingConnection() && connectionList.containsKey(connectionId)) {
         	ServiceSocket socket = connectionList.get(connectionId);
             socket.initialize();
+
+            // use new response and disconnect patterns
+            socket.setResponsePattern(this.getResponsePattern());
+            socket.setDisconnectPattern(this.getCloseConncectionPattern());
+            
             return socket;
         }
         

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerGui.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerGui.java
@@ -67,6 +67,8 @@ public class WebSocketSamplerGui extends AbstractSamplerGui {
             webSocketSamplerPanel.setProxyPort(webSocketSamplerTestElement.getProxyPort());
             webSocketSamplerPanel.setProxyUsername(webSocketSamplerTestElement.getProxyUsername());
             webSocketSamplerPanel.setMessageBacklog(webSocketSamplerTestElement.getMessageBacklog());
+            webSocketSamplerPanel.setOverrideResponsePattern(webSocketSamplerTestElement.isOverrideResponsePattern());
+            webSocketSamplerPanel.setOverrideDisconnectPattern(webSocketSamplerTestElement.isOverrideDisconnectPattern());
 
             Arguments queryStringParameters = webSocketSamplerTestElement.getQueryStringParameters();
             if (queryStringParameters != null) {
@@ -106,6 +108,9 @@ public class WebSocketSamplerGui extends AbstractSamplerGui {
             webSocketSamplerTestElement.setProxyPort(webSocketSamplerPanel.getProxyPort());
             webSocketSamplerTestElement.setProxyUsername(webSocketSamplerPanel.getProxyUsername());
             webSocketSamplerTestElement.setMessageBacklog(webSocketSamplerPanel.getMessageBacklog());
+            webSocketSamplerTestElement.setOverrideResponsePattern(webSocketSamplerPanel.isOverrideResponsePattern());
+            webSocketSamplerTestElement.setOverrideDisconnectPattern(webSocketSamplerPanel.isOverrideDisconnectPattern());
+
 
             ArgumentsPanel queryStringParameters = webSocketSamplerPanel.getAttributePanel();
             if (queryStringParameters != null) {

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.form
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.form
@@ -353,7 +353,9 @@
                           <Component id="jLabel7" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="responsePatternTextField" max="32767" attributes="0"/>
-                          <EmptySpace type="separate" max="-2" attributes="0"/>
+                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                          <Component id="overrideResponsePatternCheckBox" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
                           <Component id="jLabel16" min="-2" max="-2" attributes="0"/>
                           <EmptySpace min="-2" max="-2" attributes="0"/>
                           <Component id="messageBacklogTextField" min="-2" pref="40" max="-2" attributes="0"/>
@@ -362,6 +364,8 @@
                           <Component id="jLabel9" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="closeConncectionPatternTextField" max="32767" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="overrideDisconnectPatternCheckBox" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
@@ -376,6 +380,7 @@
                       <Group type="103" alignment="0" groupAlignment="3" attributes="0">
                           <Component id="jLabel16" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="messageBacklogTextField" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="overrideResponsePatternCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <Group type="103" groupAlignment="3" attributes="0">
                           <Component id="jLabel7" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -386,6 +391,7 @@
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel9" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="closeConncectionPatternTextField" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="overrideDisconnectPatternCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
               </Group>
@@ -413,6 +419,16 @@
           </Properties>
         </Component>
         <Component class="javax.swing.JTextField" name="messageBacklogTextField">
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="overrideResponsePatternCheckBox">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Override previous"/>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="overrideDisconnectPatternCheckBox">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Override previous"/>
+          </Properties>
         </Component>
       </SubComponents>
     </Container>

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.java
@@ -71,6 +71,8 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
         closeConncectionPatternTextField = new javax.swing.JTextField();
         jLabel16 = new javax.swing.JLabel();
         messageBacklogTextField = new javax.swing.JTextField();
+        overrideResponsePatternCheckBox = new javax.swing.JCheckBox();
+        overrideDisconnectPatternCheckBox = new javax.swing.JCheckBox();
         jPanel6 = new javax.swing.JPanel();
         jLabel10 = new javax.swing.JLabel();
         proxyAddressTextField = new javax.swing.JTextField();
@@ -250,6 +252,10 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
 
         jLabel16.setText("Message backlog:");
 
+        overrideResponsePatternCheckBox.setText("Override previous");
+
+        overrideDisconnectPatternCheckBox.setText("Override previous");
+
         javax.swing.GroupLayout jPanel5Layout = new javax.swing.GroupLayout(jPanel5);
         jPanel5.setLayout(jPanel5Layout);
         jPanel5Layout.setHorizontalGroup(
@@ -261,14 +267,18 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
                         .addComponent(jLabel7)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(responsePatternTextField)
-                        .addGap(18, 18, 18)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addComponent(overrideResponsePatternCheckBox)
+                        .addGap(6, 6, 6)
                         .addComponent(jLabel16)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(messageBacklogTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 40, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel5Layout.createSequentialGroup()
                         .addComponent(jLabel9)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(closeConncectionPatternTextField)))
+                        .addComponent(closeConncectionPatternTextField)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(overrideDisconnectPatternCheckBox)))
                 .addContainerGap())
         );
         jPanel5Layout.setVerticalGroup(
@@ -278,14 +288,16 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
                 .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                         .addComponent(jLabel16)
-                        .addComponent(messageBacklogTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addComponent(messageBacklogTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(overrideResponsePatternCheckBox))
                     .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                         .addComponent(jLabel7)
                         .addComponent(responsePatternTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel9)
-                    .addComponent(closeConncectionPatternTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(closeConncectionPatternTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(overrideDisconnectPatternCheckBox))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -413,6 +425,8 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
     private javax.swing.JPanel jPanel6;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JTextField messageBacklogTextField;
+    private javax.swing.JCheckBox overrideDisconnectPatternCheckBox;
+    private javax.swing.JCheckBox overrideResponsePatternCheckBox;
     private javax.swing.JTextField protocolTextField;
     private javax.swing.JTextField proxyAddressTextField;
     private javax.swing.JTextField proxyPasswordTextField;

--- a/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.java
+++ b/src/main/java/JMeter/plugins/functional/samplers/websocket/WebSocketSamplerPanel.java
@@ -594,7 +594,23 @@ public class WebSocketSamplerPanel extends javax.swing.JPanel {
 
     public String getMessageBacklog() {
         return messageBacklogTextField.getText();
-    }    
+    }
+    
+    public void setOverrideResponsePattern(Boolean overrideResponsePattern) {
+        overrideResponsePatternCheckBox.setSelected(overrideResponsePattern);
+    }
+    
+    public Boolean isOverrideResponsePattern() {
+        return overrideResponsePatternCheckBox.isSelected();
+    }
+    
+    public void setOverrideDisconnectPattern(Boolean overrideDisconnectPattern) {
+        overrideDisconnectPatternCheckBox.setSelected(overrideDisconnectPattern);
+    }
+    
+    public Boolean isOverrideDisconnectPattern() {
+        return overrideDisconnectPatternCheckBox.isSelected();
+    }
 
     /**
      * @return the attributePanel


### PR DESCRIPTION
This addresses #61 by allowing users to check a box to override the response/disconnect regex's specified in the first WebSocket sampler.

![Image of new interface](https://cloud.githubusercontent.com/assets/4535575/19124018/59f116e0-8aff-11e6-8630-7714322f7772.png)

When a user checks the checkbox, the response/close pattern on that row overwrites the previous response/close pattern associated with that connection, even if the current sampler's regex is blank (this would clear the previous pattern).
